### PR TITLE
Fix typo in en_us.lang

### DIFF
--- a/src/main/resources/assets/respawn-location-picker/lang/en_us.lang
+++ b/src/main/resources/assets/respawn-location-picker/lang/en_us.lang
@@ -7,7 +7,7 @@ gui.respawnLocation.title=Choose your respawn location!
 commands.addSpawnPoint.usage=/addSpawnPoint <name> [player] [x y z] [dimension]
 commands.addSpawnPoint.permissionOtherPlayers=You do not have the required permissions to add spawn points for other players!
 commands.addSpawnPoint.success=Successfully added spawn point %s
-commands.addSpawnPoint.fail=Failed to add repsawn point: %s is already a respawn point
+commands.addSpawnPoint.fail=Failed to add respawn point: %s is already a respawn point
 
 commands.clearSpawnPoints.usage=/clearSpawnPoints [player]
 commands.clearSpawnPoints.success=Successfully cleared %s spawn points


### PR DESCRIPTION
Fix typo in command failure response for en_us